### PR TITLE
Add --status option to filter job list by job status

### DIFF
--- a/src/list_jobs.py
+++ b/src/list_jobs.py
@@ -8,7 +8,7 @@ class ListJobs(GnipHistoricalCmd):
         parser.add_option("-d", "--since-date", dest="sinceDateString", default=None, 
                 help="Only list jobs after date, (default 2012-01-01T00:00:00)")
         parser.add_option("-s", "--status", dest="statusString", default=None,
-            help="Only list jobs with a specific status (options: open, quoted, accepted, rejected, running, or delivered")
+            help="Only list jobs with a specific status (options: open, quoted, accepted, rejected, running, or delivered)")
 
 
     # available statuses: rejected, accepted, running, quoted


### PR DESCRIPTION
The --status option allows the users to only list jobs with a specific status (options: open, quoted, accepted, rejected, running, or delivered).
